### PR TITLE
Use OpenID connect userinfo endpoint to validate bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ Per default no authentication is needed. To protect api, integrate it with your 
 
 * `REQUIRE_AUTHENTICATION`: Force authentication to be required (default: False)
 * `GROUP_ACCESS_ONLY`: Force visibility to templates of group only. See also `OIDC_GROUPS_CLAIM`. (default: False)
-* `OIDC_VERIFY_ALGORITHM`: Token verification algorithm (default: HS256)
-* `OIDC_CLIENT`: Client name
-* `OIDC_JWKS_ENDPOINT`: End point of JWKS in case a asymentric algorithm is used.
-* `OIDC_SECRET_KEY`: Secret key when symmetric algorithm is used (defaults to `SECRET_KEY`)
-* `OIDC_VALIDATE_CLAIMS_OPTIONS` dict of verify signature options. See [options parameter](https://python-jose.readthedocs.io/en/latest/jwt/api.html?highlight=decode_token#jose.jwt.decode) for details.
+* `OIDC_USERINFO_ENDPOINT`: Url of userinfo endpoint as [described](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to define group membership (default: document_merge_service_groups)
+
+#### Cache
+
+* `CACHE_BACKEND`: [cache backend](https://docs.djangoproject.com/en/1.11/ref/settings/#backend) to use (default: django.core.cache.backends.locmem.LocMemCache)
+* `CACHE_LOCATION`: [location](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES-LOCATION) of cache to use
+* `CACHE_TIMEOUT`: number of seconds before a cache entry is considered stale. (default: 300)
 
 ## Contributing
 

--- a/document_merge_service/conftest.py
+++ b/document_merge_service/conftest.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 
 import pytest
+from django.core.cache import cache
 from factory.base import FactoryMetaClass
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
@@ -29,6 +30,11 @@ class TestUser(AnonymousUser):
     @property
     def is_authenticated(self):
         return True
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _autoclear_cache():
+    cache.clear()
 
 
 @pytest.fixture

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -90,6 +90,7 @@ CACHES = {
             "CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache"
         ),
         "LOCATION": env.str("CACHE_LOCATION", ""),
+        "TIMEOUT": env.int("CACHE_TIMEOUT", 300),
     }
 }
 
@@ -171,14 +172,8 @@ UNOCONV_FORMATS = UNOCONV_URL and get_unoconv_formats()
 REQUIRE_AUTHENTICATION = env.bool("REQUIRE_AUTHENTICATION", False)
 GROUP_ACCESS_ONLY = env.bool("GROUP_ACCESS_ONLY", False)
 
-OIDC_VERIFY_ALGORITHM = env.list("OIDC_VERIFY_ALGORITHM", default="HS256")
-OIDC_CLIENT = env.str("OIDC_CLIENT", default=None)
-OIDC_JWKS_ENDPOINT = env.str("OIDC_JWKS_ENDPOINT", default=None)
-OIDC_SECRET_KEY = env.str("OIDC_SECRET_KEY", default=SECRET_KEY)
+OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
-OIDC_VALIDATE_CLAIMS_OPTIONS = env.dict(
-    "OIDC_VALIDATE_CLAIMS_OPTIONS", cast={"value": bool}, default=None
-)
 OIDC_GROUPS_CLAIM = env.str(
     "OIDC_GROUPS_CLAIM", default="document_merge_service_groups"
 )
@@ -194,7 +189,7 @@ REST_FRAMEWORK = {
         "document_merge_service.api.permissions.AsConfigured"
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "document_merge_service.api.authentication.OIDCAuthentication"
+        "document_merge_service.api.authentication.BearerTokenAuthentication"
     ],
     "UNAUTHENTICATED_USER": "document_merge_service.api.authentication.AnonymousUser",
     "DEFAULT_FILTER_BACKENDS": (

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,4 @@ filterwarnings =
 env =
     ADMINS=Test Example <test@example.com>,Test2 <test2@example.com>
     FILE_STORAGE=inmemorystorage.InMemoryStorage
-    OIDC_JWKS_ENDPOINT=mock://document-merge-service.github.com/openid/jwks
-    OIDC_CLIENT=document-merge-service
-    OIDC_VALIDATE_CLAIMS_OPTIONS=verify_at_hash=False
-    CACHE_BACKEND=django.core.cache.backends.dummy.DummyCache
+    OIDC_USERINFO_ENDPOINT=mock://document-merge-service.github.com/openid/userinfo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography==2.4.2
 django==1.11.18 # pyup: >=1.11,<1.12
 django-environ==0.4.5
 django-filter==2.0.0
@@ -7,7 +6,6 @@ docx-mailmerge==0.4.0
 docxtpl==0.5.14
 psycopg2-binary==2.7.6.1
 python-docx==0.8.10
-python-jose==3.0.1
-python-jose[cryptography]==3.0.1
+python-memcached==1.59
 requests==2.21.0
 uwsgi==2.0.17.1


### PR DESCRIPTION
Invalid assumptions has been made that access_token is always a JWT
token. The OpenID specification doesn't require it and only a few
IAM actually implement it that way.

This change has the additional advantage that no crypthography library
is needed within Caluma context which could have vulnerabilities.