### PR TITLE
Make caching of userinfo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Per default no authentication is needed. To protect api, integrate it with your 
 * `GROUP_ACCESS_ONLY`: Force visibility to templates of group only. See also `OIDC_GROUPS_CLAIM`. (default: False)
 * `OIDC_USERINFO_ENDPOINT`: Url of userinfo endpoint as [described](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to define group membership (default: document_merge_service_groups)
+* `OIDC_BEARER_TOKEN_REVALIDATION_TIME`: Time in seconds before bearer token validity is verified again. For best security token is validated on each request per default. It might be helpful though in case of slow Open ID Connect provider to cache it. It uses [cache](#cache) mechanism for memorizing userinfo result. Number has to be lower than access token expiration time. (default: 0)
 
 #### Cache
 
 * `CACHE_BACKEND`: [cache backend](https://docs.djangoproject.com/en/1.11/ref/settings/#backend) to use (default: django.core.cache.backends.locmem.LocMemCache)
 * `CACHE_LOCATION`: [location](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES-LOCATION) of cache to use
-* `CACHE_TIMEOUT`: number of seconds before a cache entry is considered stale. (default: 300)
 
 ## Contributing
 

--- a/document_merge_service/api/authentication.py
+++ b/document_merge_service/api/authentication.py
@@ -86,7 +86,9 @@ class BearerTokenAuthentication(authentication.BaseAuthentication):
 
         userinfo_method = functools.partial(self.get_userinfo, token=token)
         userinfo = cache.get_or_set(
-            f"authentication.userinfo.{smart_text(token)}", userinfo_method
+            f"authentication.userinfo.{smart_text(token)}",
+            userinfo_method,
+            timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
         )
 
         return OIDCUser(userinfo), token

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -93,7 +93,6 @@ CACHES = {
             "CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache"
         ),
         "LOCATION": env.str("CACHE_LOCATION", ""),
-        "TIMEOUT": env.int("CACHE_TIMEOUT", 300),
     }
 }
 
@@ -179,6 +178,9 @@ OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_GROUPS_CLAIM = env.str(
     "OIDC_GROUPS_CLAIM", default="document_merge_service_groups"
+)
+OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
+    "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
 )
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ env =
     ADMINS=Test Example <test@example.com>,Test2 <test2@example.com>
     FILE_STORAGE=inmemorystorage.InMemoryStorage
     OIDC_USERINFO_ENDPOINT=mock://document-merge-service.github.com/openid/userinfo
+    OIDC_BEARER_TOKEN_REVALIDATION_TIME=60


### PR DESCRIPTION
This could be a security issue if in case access token expires before
cache expires. Hence disabled by default but might still be helpful
to cache in case OpenID Connect provider is slow.