### PR TITLE
Use hashsum of token for userinfo caching

### DIFF
--- a/document_merge_service/api/authentication.py
+++ b/document_merge_service/api/authentication.py
@@ -1,9 +1,10 @@
 import functools
+import hashlib
 
 import requests
 from django.conf import settings
 from django.core.cache import cache
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_bytes, smart_text
 from django.utils.translation import ugettext as _
 from rest_framework import authentication, exceptions
 
@@ -85,8 +86,10 @@ class BearerTokenAuthentication(authentication.BaseAuthentication):
             return None
 
         userinfo_method = functools.partial(self.get_userinfo, token=token)
+        # token might be too long for key so we use hash sum instead.
+        hashsum_token = hashlib.sha256(force_bytes(token)).hexdigest()
         userinfo = cache.get_or_set(
-            f"authentication.userinfo.{smart_text(token)}",
+            f"authentication.userinfo.{hashsum_token}",
             userinfo_method,
             timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
         )

--- a/document_merge_service/api/tests/test_authentication.py
+++ b/document_merge_service/api/tests/test_authentication.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 import pytest
@@ -39,7 +40,12 @@ def test_bearer_token_authentication_authenticate(
             user, auth = result
             assert user.is_authenticated
             assert user.group == "test"
-            assert cache.get("authentication.userinfo.Token") == userinfo
+            assert (
+                cache.get(
+                    f"authentication.userinfo.{hashlib.sha256(b'Token').hexdigest()}"
+                )
+                == userinfo
+            )
 
 
 def test_bearer_token_authentication_header(rf):


### PR DESCRIPTION
Some token especially of providers which use JWT also for access tokens
are too long for memcache key limit of 250 so the need to be hashed.