### PR TITLE
[BUGFIX] write content_type to header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ target/
 
 # Editor swap files
 *.swp
+
+# IDE specific configuration
+.idea/

--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -127,6 +127,10 @@ def test_template_merge_docx(db, client, template, snapshot):
 
     response = client.post(url, data={"data": {"test": "Test input"}}, format="json")
     assert response.status_code == status.HTTP_200_OK
+    assert (
+        response._headers["content-type"][1]
+        == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
 
     docx = Document(io.BytesIO(response.content))
     xml = etree.tostring(docx._element.body, encoding="unicode", pretty_print=True)

--- a/document_merge_service/api/views.py
+++ b/document_merge_service/api/views.py
@@ -36,7 +36,9 @@ class TemplateView(viewsets.ModelViewSet):
         engine = engines.get_engine(template.engine, template.template)
 
         content_type, _ = mimetypes.guess_type(template.template.name)
-        response = HttpResponse(content_type or "application/force-download")
+        response = HttpResponse(
+            content_type=content_type or "application/force-download"
+        )
         extension = mimetypes.guess_extension(content_type)
 
         serializer = self.get_serializer(data=request.data)


### PR DESCRIPTION
In `TemplateView.merge()` the content_type was written to `response.content` which resulted in broken documents.

Additional change: added `.idea/` to .gitignore.

Closes #72