### PR TITLE
Provide a way to use a local unoconv process

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Per default [Sqlite3](https://sqlite.org/) is used as database for simple deploy
 
 * `UNOCONV_URL`: url to [tfk-api-unoconv service](https://github.com/zrrrzzt/tfk-api-unoconv) (e.g. http://localhost:3000)
 * `UNOCONV_ALLOWED_TYPES`: list of types allowed to convert to. See [supported formats](https://github.com/zrrrzzt/tfk-api-unoconv#formats) (default: ['pdf'])
+* `UNOCONV_LOCAL`: boolean to indicate if a local unoconv CLI should be used instead of the webservice. Defaults to `False`
+* `UNOCONV_PYTHON`: string (only needed if `UNOCONV_LOCAL` is `True`) defaults to "/usr/bin/python3.5"
+* `UNOCONV_PATH`: string (only needed if `UNOCONV_LOCAL` is `True`) defaults to "/usr/bin/unoconv"
 
 #### python-docx-template
 * `DOCXTEMPLATE_JINJA_EXTENSIONS`: list of [jinja2 extensions](http://jinja.pocoo.org/docs/2.10/extensions/) to load

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,9 @@ services:
     build:
       context: .
       args:
-        REQUIREMENTS: requirements-dev.txt
+        - REQUIREMENTS=requirements-dev.txt
+        - UID=$UID
+        - UNOCONV_LOCAL=true
     user: "${UID:?Set UID env variable to your user id}"
     volumes:
       - ./:/app

--- a/document_merge_service/api/serializers.py
+++ b/document_merge_service/api/serializers.py
@@ -53,7 +53,7 @@ class TemplateMergeSerializer(serializers.Serializer):
     )
 
     def validate_convert(self, value):
-        if not settings.UNOCONV_URL:
+        if not settings.UNOCONV_URL and not settings.UNOCONV_LOCAL:
             raise ImproperlyConfigured(
                 "To use conversion you need to configure `UNOCONV_URL`"
             )

--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -143,11 +143,19 @@ def test_template_merge_docx(db, client, template, snapshot):
         raise
 
 
+# This needs a strange parametrization. If `unoconv_local` is in a separate
+# `parametrize()`, the template filename in the second test will be appended with a
+# hash and the test fails
 @pytest.mark.parametrize(
-    "template__engine,template__template",
-    [(models.Template.DOCX_TEMPLATE, django_file("docx-template.docx"))],
+    "template__engine,template__template,unoconv_local",
+    [
+        (models.Template.DOCX_TEMPLATE, django_file("docx-template.docx"), True),
+        (models.Template.DOCX_TEMPLATE, django_file("docx-template.docx"), False),
+    ],
 )
-def test_template_merge_as_pdf(db, client, template):
+def test_template_merge_as_pdf(db, settings, unoconv_local, client, template):
+    settings.UNOCONV_LOCAL = unoconv_local
+    settings.UNOCONV_URL = "" if unoconv_local else "http://unoconv:3000"
     url = reverse("template-merge", args=[template.pk])
 
     response = client.post(

--- a/document_merge_service/api/unoconv.py
+++ b/document_merge_service/api/unoconv.py
@@ -1,0 +1,68 @@
+import re
+import subprocess
+from collections import namedtuple
+from mimetypes import guess_type
+
+UnoconvResult = namedtuple(
+    "UnoconvResult", ["stdout", "stderr", "returncode", "content_type"]
+)
+
+
+class Unoconv:
+    def __init__(self, pythonpath, unoconvpath):
+        self.pythonpath = pythonpath
+        self.unoconvpath = unoconvpath
+
+    def get_formats(self):
+        p = subprocess.run(
+            [self.pythonpath, self.unoconvpath, "--show"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if not p.returncode == 0:  # pragma: no cover
+            raise Exception("Failed to fetch the formats from unoconv!")
+
+        formats = []
+        for line in p.stderr.decode("utf-8").split("\n"):
+            if line.startswith("  "):
+                match = re.match(r"^\s\s(?P<format>[a-z]*)\s", line)
+                if match:
+                    formats.append(match.group("format"))
+
+        return set(formats)
+
+    def process(self, filename, convert):
+        """
+        Convert a file.
+
+        :param filename: str()
+        :param convert: str() - target format. e.g. "pdf"
+        :return: UnoconvResult()
+        """
+        # unoconv MUST be running with the same python version as libreoffice
+        p = subprocess.run(
+            [
+                self.pythonpath,
+                self.unoconvpath,
+                "--format",
+                convert,
+                "--stdout",
+                filename,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout = p.stdout
+        if not p.returncode == 0:  # pragma: no cover
+            stdout = f"unoconv returncode: {p.returncode}"
+
+        content_type, _ = guess_type(f"something.{convert}")
+
+        result = UnoconvResult(
+            stdout=stdout,
+            stderr=p.stderr,
+            returncode=p.returncode,
+            content_type=content_type,
+        )
+
+        return result

--- a/document_merge_service/api/views.py
+++ b/document_merge_service/api/views.py
@@ -1,4 +1,5 @@
 import mimetypes
+from tempfile import NamedTemporaryFile
 
 import requests
 from django.conf import settings
@@ -9,6 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.generics import RetrieveAPIView
 
 from . import engines, models, serializers
+from .unoconv import Unoconv
 
 
 class TemplateView(viewsets.ModelViewSet):
@@ -48,17 +50,35 @@ class TemplateView(viewsets.ModelViewSet):
         convert = serializer.data.get("convert")
 
         if convert:
-            url = f"{settings.UNOCONV_URL}/unoconv/{convert}"
-            requests_response = requests.post(url, files={"file": response.content})
-            fmt = settings.UNOCONV_FORMATS[convert]
-            extension = fmt["extension"]
-            content_type = fmt["mime"]
+            if settings.UNOCONV_LOCAL:
+                with NamedTemporaryFile("wb") as tmp:
+                    tmp.write(response.content)
+                    unoconv = Unoconv(
+                        pythonpath=settings.UNOCONV_PYTHON,
+                        unoconvpath=settings.UNOCONV_PATH,
+                    )
+                    result = unoconv.process(tmp.name, convert)
+                extension = convert
+                status = 500
+                if result.returncode == 0:
+                    status = 200
+                response = HttpResponse(
+                    content=result.stdout,
+                    status=status,
+                    content_type=result.content_type,
+                )
+            else:
+                url = f"{settings.UNOCONV_URL}/unoconv/{convert}"
+                requests_response = requests.post(url, files={"file": response.content})
+                fmt = settings.UNOCONV_FORMATS[convert]
+                extension = fmt["extension"]
+                content_type = fmt["mime"]
 
-            response = HttpResponse(
-                content=requests_response.content,
-                status=requests_response.status_code,
-                content_type=content_type,
-            )
+                response = HttpResponse(
+                    content=requests_response.content,
+                    status=requests_response.status_code,
+                    content_type=content_type,
+                )
 
         filename = f"{template.slug}.{extension}"
         response["Content-Disposition"] = f'attachment; filename="{filename}"'

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -6,6 +6,8 @@ import requests
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import status
 
+from .api.unoconv import Unoconv
+
 env = environ.Env()
 django_root = environ.Path(__file__) - 2
 
@@ -157,6 +159,9 @@ MEDIA_ROOT = env.str("MEDIA_ROOT", "")
 
 UNOCONV_ALLOWED_TYPES = env.list("UNOCOV_ALLOWED_TYPES", default=["pdf"])
 UNOCONV_URL = env.str("UNOCONV_URL", default="").rstrip("/")
+UNOCONV_LOCAL = env.bool("UNOCONV_LOCAL", default=False)
+UNOCONV_PYTHON = env.str("UNOCONV_PYTHON", default="/usr/bin/python3.5")
+UNOCONV_PATH = env.str("UNOCONV_PATH", default="/usr/bin/unoconv")
 
 
 def get_unoconv_formats():
@@ -177,7 +182,24 @@ def get_unoconv_formats():
     return formats
 
 
-UNOCONV_FORMATS = UNOCONV_URL and get_unoconv_formats()
+def get_unoconv_formats_local():
+    uno = Unoconv(pythonpath=UNOCONV_PYTHON, unoconvpath=UNOCONV_PATH)
+    formats = uno.get_formats()
+    not_supported = set(UNOCONV_ALLOWED_TYPES) - formats
+
+    if not_supported:
+        raise ImproperlyConfigured(
+            f"Unoconv doesn't support types {', '.join(not_supported)}."
+        )
+
+    return formats
+
+
+UNOCONV_FORMATS = False
+if UNOCONV_LOCAL:  # pragma: no cover
+    UNOCONV_FORMATS = get_unoconv_formats_local()
+elif UNOCONV_URL:
+    UNOCONV_FORMATS = get_unoconv_formats()
 
 # Jinja2
 DOCXTEMPLATE_JINJA_EXTENSIONS = env.list(

--- a/document_merge_service/tests/test_settings.py
+++ b/document_merge_service/tests/test_settings.py
@@ -4,8 +4,11 @@ from django.core.exceptions import ImproperlyConfigured
 from .. import settings
 
 
-def test_get_unoconv_formats():
-    formats = settings.get_unoconv_formats()
+@pytest.mark.parametrize(
+    "format_function", ["get_unoconv_formats", "get_unoconv_formats_local"]
+)
+def test_get_unoconv_formats(format_function):
+    formats = getattr(settings, format_function)()
     assert "pdf" in formats
 
 
@@ -16,8 +19,11 @@ def test_get_unoconv_formats_invalid_url(monkeypatch):
         settings.get_unoconv_formats()
 
 
-def test_get_unoconv_formats_invalid_format(monkeypatch):
+@pytest.mark.parametrize(
+    "format_function", ["get_unoconv_formats", "get_unoconv_formats_local"]
+)
+def test_get_unoconv_formats_invalid_format(monkeypatch, format_function):
     monkeypatch.setattr(settings, "UNOCONV_ALLOWED_TYPES", ["invalid"])
 
     with pytest.raises(ImproperlyConfigured):
-        settings.get_unoconv_formats()
+        getattr(settings, format_function)()


### PR DESCRIPTION
This commit implements a way to use the unoconv CLI instead of the
webservice container.

Usage of this is discouraged and only useful if the target platform has
some kind of restrictions about what (and how many) services are allowed
to run.