### PR TITLE
Use python3 binary to run unoconv

### DIFF
--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -160,7 +160,7 @@ MEDIA_ROOT = env.str("MEDIA_ROOT", "")
 UNOCONV_ALLOWED_TYPES = env.list("UNOCOV_ALLOWED_TYPES", default=["pdf"])
 UNOCONV_URL = env.str("UNOCONV_URL", default="").rstrip("/")
 UNOCONV_LOCAL = env.bool("UNOCONV_LOCAL", default=False)
-UNOCONV_PYTHON = env.str("UNOCONV_PYTHON", default="/usr/bin/python3.5")
+UNOCONV_PYTHON = env.str("UNOCONV_PYTHON", default="/usr/bin/python3")
 UNOCONV_PATH = env.str("UNOCONV_PATH", default="/usr/bin/unoconv")
 
 


### PR DESCRIPTION
python version may differ in different distributions but it is common
practice to provide python3. This binary will also be local and not overwritten by pyenv or locally
with pyenv so tests can be run locally again.

This fixes issue CI currently not running as docker container updated to
Debian buster.