### PR TITLE
Add option to call groups api for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,14 @@ Per default [Sqlite3](https://sqlite.org/) is used as database for simple deploy
 Per default no authentication is needed. To protect api, integrate it with your [IAM](https://en.wikipedia.org/wiki/Identity_management) supporting Open ID Connect. If not availbale you might consider using [Keycloak](https://www.keycloak.org/).
 
 * `REQUIRE_AUTHENTICATION`: Force authentication to be required (default: False)
-* `GROUP_ACCESS_ONLY`: Force visibility to templates of group only. See also `OIDC_GROUPS_CLAIM`. (default: False)
+* `GROUP_ACCESS_ONLY`: Force visibility to templates of group only. See also `OIDC_GROUPS_CLAIM` or `OIDC_GROUPS_API` (default: False)
 * `OIDC_USERINFO_ENDPOINT`: Url of userinfo endpoint as [described](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
+* `OIDC_VERIFY_SSL`: Verify ssl certificate of oidc userinfo endpoint (default: True)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to define group membership (default: document_merge_service_groups)
+* `OIDC_GROUPS_API`: In case authorization is done in a different service than your OpenID Connect provider you may specify an API endpoint returning JSON which is called after authentication. Use `{sub}` as placeholder for username. Replace `sub` with any claim name. Example: https://example.net/users/{sub}/
+* `OIDC_GROUPS_API_VERIFY_SSL`: Verify ssl certificate of groups api endpoint (default: True)
+* `OIDC_GROUPS_API_JSONPATH`: [Json path expression](https://goessner.net/articles/JsonPath/index.html) to match groups in json returned by `OIDC_GROUPS_API`. See also [JSONPath online evaluator](https://jsonpath.com/)
+* `OIDC_GROUPS_API_HEADER`: List of headers which are passed on to groups api. (default: ['AUTHENTICATION'])
 * `OIDC_BEARER_TOKEN_REVALIDATION_TIME`: Time in seconds before bearer token validity is verified again. For best security token is validated on each request per default. It might be helpful though in case of slow Open ID Connect provider to cache it. It uses [cache](#cache) mechanism for memorizing userinfo result. Number has to be lower than access token expiration time. (default: 0)
 
 #### Cache

--- a/document_merge_service/api/authentication.py
+++ b/document_merge_service/api/authentication.py
@@ -89,7 +89,7 @@ class BearerTokenAuthentication(authentication.BaseAuthentication):
             if key.startswith("HTTP_") and key[5:] in settings.OIDC_GROUPS_API_HEADERS
         }
 
-        # replae placerholders
+        # replace placeholders
         groups_api = settings.OIDC_GROUPS_API
         for key, value in userinfo.items():
             groups_api = groups_api.replace("{" + key + "}", value)

--- a/document_merge_service/api/tests/test_authentication.py
+++ b/document_merge_service/api/tests/test_authentication.py
@@ -22,10 +22,11 @@ from .. import authentication
 def test_bearer_token_authentication_authenticate(
     rf, authentication_header, error, requests_mock, settings, status_code
 ):
-    userinfo = {"sub": "1", settings.OIDC_GROUPS_CLAIM: ["test"]}
+    userinfo = {"sub": "1"}
     requests_mock.get(
         settings.OIDC_USERINFO_ENDPOINT,
         status_code=status_code,
+        request_headers={"Authorization": authentication_header},
         text=json.dumps(userinfo),
     )
 
@@ -39,13 +40,67 @@ def test_bearer_token_authentication_authenticate(
         if result:
             user, auth = result
             assert user.is_authenticated
-            assert user.group == "test"
             assert (
                 cache.get(
                     f"authentication.userinfo.{hashlib.sha256(b'Token').hexdigest()}"
                 )
                 == userinfo
             )
+
+
+def test_bearer_token_authentication_authenticate_groups_claim(
+    settings, requests_mock, rf
+):
+    settings.OIDC_GROUPS_CLAIM = "document-merge-service"
+
+    userinfo = {"sub": "1", settings.OIDC_GROUPS_CLAIM: ["test"]}
+    requests_mock.get(settings.OIDC_USERINFO_ENDPOINT, text=json.dumps(userinfo))
+
+    request = rf.get("/openid", HTTP_AUTHORIZATION="Bearer Token")
+    user, auth = authentication.BearerTokenAuthentication().authenticate(request)
+    assert user.is_authenticated
+    assert user.group == "test"
+    assert user.groups == ["test"]
+
+
+@pytest.mark.parametrize(
+    "status_code,error",
+    [(status.HTTP_200_OK, False), (status.HTTP_400_BAD_REQUEST, True)],
+)
+def test_bearer_token_authentication_authenticate_groups_api(
+    settings, requests_mock, rf, status_code, error
+):
+    settings.OIDC_GROUPS_API = (
+        "mock://document-merge-service.github.com/user/{sub}/groups"
+    )
+    settings.OIDC_GROUPS_API_JSONPATH = "$..*"
+
+    userinfo = {"sub": "1"}
+    requests_mock.get(
+        settings.OIDC_USERINFO_ENDPOINT,
+        request_headers={"Authorization": "Bearer Token"},
+        text=json.dumps(userinfo),
+    )
+    requests_mock.get(
+        settings.OIDC_GROUPS_API.replace("{sub}", "1"),
+        status_code=status_code,
+        text=json.dumps(["test", "test2"]),
+    )
+
+    request = rf.get("/openid", HTTP_AUTHORIZATION="Bearer Token")
+    try:
+        user, auth = authentication.BearerTokenAuthentication().authenticate(request)
+    except exceptions.AuthenticationFailed:
+        assert error
+    else:
+        assert not error
+        assert user.is_authenticated
+        assert user.group == "test"
+        assert user.groups == ["test", "test2"]
+        assert (
+            cache.get(f"authentication.groups.{hashlib.sha256(b'Token').hexdigest()}")
+            == user.groups
+        )
 
 
 def test_bearer_token_authentication_header(rf):

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -213,12 +213,22 @@ GROUP_ACCESS_ONLY = env.bool("GROUP_ACCESS_ONLY", False)
 
 OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
-OIDC_GROUPS_CLAIM = env.str(
-    "OIDC_GROUPS_CLAIM", default="document_merge_service_groups"
-)
+OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="")
+OIDC_GROUPS_API = env.str("OIDC_GROUPS_API", default="")
+OIDC_GROUPS_API_VERIFY_SSL = env.str("OIDC_GROUPS_API_VERIFY_SSL", default=True)
+OIDC_GROUPS_API_JSONPATH = env.str("OIDC_GROUPS_API_JSONPATH", default="")
+OIDC_GROUPS_API_HEADERS = [
+    header.upper()
+    for header in env.list("OIDC_GROUPS_API_HEADERS", default=["AUTHORIZATION"])
+]
 OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
     "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
 )
+
+if OIDC_GROUPS_API and not OIDC_GROUPS_API_JSONPATH:  # pragma: no cover
+    raise ImproperlyConfigured(
+        f"OIDC_GROUSP_API` is set to {OIDC_GROUPS_API} but no `OIDC_GROUPS_API_JSONPATH` is configured."
+    )
 
 
 # Rest framework

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-filter==2.1.0
 djangorestframework==3.9.4
 docx-mailmerge==0.4.0
 docxtpl==0.6.3
+jsonpath==0.82
 mysqlclient==1.4.2.post1
 psycopg2-binary==2.8.3
 python-memcached==1.59


### PR DESCRIPTION
Up to now Document Merge Service only supported authorization through OpenID Connect.
This change allows beside using OpenID Connect as authentication to use any service with a json api to be used as authorization service returning list of groups.