### PR TITLE
Do not proxy jsonpath environ value with a leading $

### DIFF
--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -216,7 +216,9 @@ OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="")
 OIDC_GROUPS_API = env.str("OIDC_GROUPS_API", default="")
 OIDC_GROUPS_API_VERIFY_SSL = env.str("OIDC_GROUPS_API_VERIFY_SSL", default=True)
-OIDC_GROUPS_API_JSONPATH = env.str("OIDC_GROUPS_API_JSONPATH", default="")
+# environ interprets leading jsonpath dollar to be an proxied environ var
+# which is not the case
+OIDC_GROUPS_API_JSONPATH = os.environ.get("OIDC_GROUPS_API_JSONPATH", "")
 OIDC_GROUPS_API_HEADERS = [
     header.upper()
     for header in env.list("OIDC_GROUPS_API_HEADERS", default=["AUTHORIZATION"])


### PR DESCRIPTION
django-environ determines a variable with a leading $ as a proxied environment variables which is not the case in jsonpath hence need to use envrion directly.