### PR TITLE
Allow search lookup to be used in sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Different environment variable types are explained at [django-environ](https://g
 
 #### Database
 
-Per default [Sqlite3](https://sqlite.org/) is used as database for simple deployment. To scale service a different database storage is needed. Any database supported by [Django](https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-DATABASE-ENGINE) can be used.
+Per default [Sqlite3](https://sqlite.org/) is used as database for simple deployment and stored at `/var/lib/document-merge-service/data/sqlite3.db`. Create a volume to make it persistent.
+
+To scale service a different database storage is needed. Any database supported by [Django](https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-DATABASE-ENGINE) can be used.
 
 * `DATABASE_ENGINE`: Database backend to use.
 * `DATABASE_HOST`: Host to use when connecting to database

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Different environment variable types are explained at [django-environ](https://g
 
 Per default [Sqlite3](https://sqlite.org/) is used as database for simple deployment and stored at `/var/lib/document-merge-service/data/sqlite3.db`. Create a volume to make it persistent.
 
-To scale service a different database storage is needed. Any database supported by [Django](https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-DATABASE-ENGINE) can be used.
+To scale the service a different database storage is needed. Any database supported by [Django](https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-DATABASE-ENGINE) can be used.
 
 * `DATABASE_ENGINE`: Database backend to use.
 * `DATABASE_HOST`: Host to use when connecting to database

--- a/document_merge_service/api/apps.py
+++ b/document_merge_service/api/apps.py
@@ -1,5 +1,12 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.db.models import TextField
+from django.db.models.lookups import IContains
 
 
 class DefaultConfig(AppConfig):
     name = "document_merge_service.api"
+
+    def ready(self):
+        if "sqlite3" in settings.DATABASES["default"]["ENGINE"]:  # pragma: no cover
+            TextField.register_lookup(IContains, lookup_name="search")

--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -15,13 +15,33 @@ from .data import django_file
     "template__group,group_access_only,size",
     [(None, False, 1), ("admin", True, 1), ("unknown", True, 0), ("unknown", False, 1)],
 )
-def test_template_list(
+def test_template_list_group_access(
     db, admin_client, template, snapshot, size, group_access_only, settings
 ):
     settings.GROUP_ACCESS_ONLY = group_access_only
     url = reverse("template-list")
 
     response = admin_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["count"] == size
+
+
+@pytest.mark.parametrize("template__description", ["test description"])
+@pytest.mark.parametrize(
+    "query_params,size",
+    [
+        ({"description__icontains": "test"}, 1),
+        ({"description__search": "test"}, 1),
+        ({"description__icontains": "unknown"}, 0),
+        ({"description__search": "unknown"}, 0),
+    ],
+)
+def test_template_list_query_params(
+    db, admin_client, template, snapshot, size, query_params
+):
+    url = reverse("template-list")
+
+    response = admin_client.get(url, data=query_params)
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["count"] == size
 


### PR DESCRIPTION
For this to work we simply fallback to icontains. Mysql and Postgres will still use their full text search.

This is a perquisite to get django 2.2 running.