### PR TITLE
fix: return templates which have no group to everyone

### DIFF
--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -13,13 +13,23 @@ from .data import django_file
 
 @pytest.mark.parametrize(
     "template__group,group_access_only,size",
-    [(None, False, 1), ("admin", True, 1), ("unknown", True, 0), ("unknown", False, 1)],
+    [(None, False, 2), ("admin", True, 2), ("unknown", True, 1), ("unknown", False, 2)],
 )
 def test_template_list_group_access(
-    db, admin_client, template, snapshot, size, group_access_only, settings
+    db,
+    admin_client,
+    template,
+    template_factory,
+    snapshot,
+    size,
+    group_access_only,
+    settings,
 ):
     settings.GROUP_ACCESS_ONLY = group_access_only
     url = reverse("template-list")
+
+    # add a global template (no group)
+    template_factory()
 
     response = admin_client.get(url)
     assert response.status_code == status.HTTP_200_OK

--- a/document_merge_service/api/views.py
+++ b/document_merge_service/api/views.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 
 import requests
 from django.conf import settings
+from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.encoding import smart_str
 from rest_framework import viewsets
@@ -24,7 +25,9 @@ class TemplateView(viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         if settings.GROUP_ACCESS_ONLY:
-            queryset = queryset.filter(group__in=self.request.user.groups)
+            queryset = queryset.filter(
+                Q(group__in=self.request.user.groups) | Q(group__isnull=True)
+            )
 
         return queryset
 


### PR DESCRIPTION
This allows global templates.