### PR TITLE
fix: add "dev" tag for dev images

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   document-merge-service:
+    image: adfinissygroup/document-merge-service:dev
     build:
       context: .
       args:


### PR DESCRIPTION
This makes sure that dev images (with dev deps) aren't used in other
projects that expect "non-dev" images.