### PR TITLE
Split re-validation time of token and groups api

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Per default no authentication is needed. To protect api, integrate it with your 
 * `OIDC_VERIFY_SSL`: Verify ssl certificate of oidc userinfo endpoint (default: True)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to define group membership (default: document_merge_service_groups)
 * `OIDC_GROUPS_API`: In case authorization is done in a different service than your OpenID Connect provider you may specify an API endpoint returning JSON which is called after authentication. Use `{sub}` as placeholder for username. Replace `sub` with any claim name. Example: https://example.net/users/{sub}/
+* `OIDC_GROUPS_API_REVALIDATION_TIME`: Time in seconds before groups api is called again.
 * `OIDC_GROUPS_API_VERIFY_SSL`: Verify ssl certificate of groups api endpoint (default: True)
 * `OIDC_GROUPS_API_JSONPATH`: [Json path expression](https://goessner.net/articles/JsonPath/index.html) to match groups in json returned by `OIDC_GROUPS_API`. See also [JSONPath online evaluator](https://jsonpath.com/)
 * `OIDC_GROUPS_API_HEADER`: List of headers which are passed on to groups api. (default: ['AUTHENTICATION'])

--- a/document_merge_service/api/authentication.py
+++ b/document_merge_service/api/authentication.py
@@ -133,7 +133,7 @@ class BearerTokenAuthentication(authentication.BaseAuthentication):
             groups = cache.get_or_set(
                 f"authentication.groups.{hashsum_token}",
                 groups_api_method,
-                timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
+                timeout=settings.OIDC_GROUPS_API_REVALIDATION_TIME,
             )
 
         return AuthenticatedUser(userinfo["sub"], groups), token

--- a/document_merge_service/api/tests/test_authentication.py
+++ b/document_merge_service/api/tests/test_authentication.py
@@ -74,6 +74,7 @@ def test_bearer_token_authentication_authenticate_groups_api(
         "mock://document-merge-service.github.com/user/{sub}/groups"
     )
     settings.OIDC_GROUPS_API_JSONPATH = "$..*"
+    settings.OIDC_GROUPS_API_REVALIDATION_TIME = 60
 
     userinfo = {"sub": "1", "groups": []}
     requests_mock.get(

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -215,6 +215,9 @@ OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="")
 OIDC_GROUPS_API = env.str("OIDC_GROUPS_API", default="")
+OIDC_GROUPS_API_REVALIDATION_TIME = env.int(
+    "OIDC_GROUPS_API_REVALIDATION_TIME", default=0
+)
 OIDC_GROUPS_API_VERIFY_SSL = env.str("OIDC_GROUPS_API_VERIFY_SSL", default=True)
 # environ interprets leading jsonpath dollar to be an proxied environ var
 # which is not the case


### PR DESCRIPTION
This needs to be split as it is different service with different characteristics.