### PR TITLE
feat(logging): add basic logging config

### DIFF
--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -256,3 +256,17 @@ REST_FRAMEWORK = {
     ),
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
+
+# Logging
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "level": "WARNING",
+            "filters": None,
+            "class": "logging.StreamHandler",
+        }
+    },
+    "loggers": {"django": {"handlers": ["console"], "level": "WARNING"}},
+}


### PR DESCRIPTION
This commit adds a basic logging config. This makes sure traces get
printed in the uwsgi log.