### PR TITLE
feat: Replace tfk-api-unoconv service with unoconv listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.6
 
 WORKDIR /app
 
-ARG UNOCONV_LOCAL=false
 ARG UID=901
 
 RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
@@ -11,11 +10,11 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
 && useradd -u $UID -r document-merge-service --create-home \
 && mkdir /home/document-merge-service/.config \
 && chmod -R 770 /var/lib/document-merge-service/data /var/lib/document-merge-service/media /var/www/static /home/document-merge-service \
-&& bash -c 'if [ "$UNOCONV_LOCAL" = true ]; then apt-get update && apt-get install -y --no-install-recommends unoconv libreoffice-writer && rm -rf /var/lib/apt/lists/*; fi' \
-# all project specific folders need to be accessible by newly created user but also for unknown users (when UID is set manually). Such users are in group root.
+&& apt-get update && apt-get install -y --no-install-recommends unoconv libreoffice-writer && rm -rf /var/lib/apt/lists/* \
+# All project specific folders need to be accessible by newly created user but also for unknown users (when UID is set manually). Such users are in group root.
 && chown -R document-merge-service:root /var/lib/document-merge-service/data /var/lib/document-merge-service/media /var/www/static /home/document-merge-service
 
-# needs to be set for users with manually set UID
+# Needs to be set for users with manually set UID
 ENV HOME=/home/document-merge-service
 
 ENV PYTHONUNBUFFERED=1

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ test: ## Test the project
 
 shell: ## Shell into document merge service
 	@docker-compose exec document-merge-service bash
+
+format: ## Format python code with black
+	@docker-compose exec document-merge-service black .

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ To scale the service a different database storage is needed. Any database suppor
 #### Unoconv
 
 * `UNOCONV_ALLOWED_TYPES`: list of types allowed to convert to. See `unoconv --show` (default: ['pdf'])
-* `UNOCONV_SERVER`: hostname or ip of unoconv listener. Defaults to `None`.
+* `UNOCONV_SERVER`: hostname or ip of unoconv listener. If no server is specified a local unoconv
+   listener inside the container is used. Defaults to `None`.
 * `UNOCONV_PORT`: port of unoconv listener. Only relevant if `UNOCONV_SERVER` is set. Defaults to `2002`.
 * `UNOCONV_PYTHON`: string defaults to "/usr/bin/python3.5"
 * `UNOCONV_PATH`: string defaults to "/usr/bin/unoconv"

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ To scale the service a different database storage is needed. Any database suppor
 
 #### Unoconv
 
-* `UNOCONV_URL`: url to [tfk-api-unoconv service](https://github.com/zrrrzzt/tfk-api-unoconv) (e.g. http://localhost:3000)
-* `UNOCONV_ALLOWED_TYPES`: list of types allowed to convert to. See [supported formats](https://github.com/zrrrzzt/tfk-api-unoconv#formats) (default: ['pdf'])
-* `UNOCONV_LOCAL`: boolean to indicate if a local unoconv CLI should be used instead of the webservice. Defaults to `False`
-* `UNOCONV_PYTHON`: string (only needed if `UNOCONV_LOCAL` is `True`) defaults to "/usr/bin/python3.5"
-* `UNOCONV_PATH`: string (only needed if `UNOCONV_LOCAL` is `True`) defaults to "/usr/bin/unoconv"
+* `UNOCONV_ALLOWED_TYPES`: list of types allowed to convert to. See `unoconv --show` (default: ['pdf'])
+* `UNOCONV_SERVER`: hostname or ip of unoconv listener. Defaults to `None`.
+* `UNOCONV_PORT`: port of unoconv listener. Only relevant if `UNOCONV_SERVER` is set. Defaults to `2002`.
+* `UNOCONV_PYTHON`: string defaults to "/usr/bin/python3.5"
+* `UNOCONV_PATH`: string defaults to "/usr/bin/unoconv"
 
 #### python-docx-template
 * `DOCXTEMPLATE_JINJA_EXTENSIONS`: list of [jinja2 extensions](http://jinja.pocoo.org/docs/2.10/extensions/) to load

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,6 @@ services:
       args:
         - REQUIREMENTS=requirements-dev.txt
         - UID=$UID
-        - UNOCONV_LOCAL=true
     user: "${UID:?Set UID env variable to your user id}"
     volumes:
       - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,10 @@ services:
       # - ALLOWED_HOSTS=
   # optional unoconv service for conversion
   unoconv:
-    image: zrrrzzt/docker-unoconv-webservice:8.9.4
+    build:
+      context: unoconv
+    ports:
+      - "2002:2002"
 
 volumes:
   dbdata:

--- a/document_merge_service/api/serializers.py
+++ b/document_merge_service/api/serializers.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions, serializers
 
@@ -51,11 +50,3 @@ class TemplateMergeSerializer(serializers.Serializer):
         choices=settings.UNOCONV_ALLOWED_TYPES,
         help_text="Optionally convert result document to this type.",
     )
-
-    def validate_convert(self, value):
-        if not settings.UNOCONV_URL and not settings.UNOCONV_LOCAL:
-            raise ImproperlyConfigured(
-                "To use conversion you need to configure `UNOCONV_URL`"
-            )
-
-        return value

--- a/document_merge_service/api/tests/test_unoconv.py
+++ b/document_merge_service/api/tests/test_unoconv.py
@@ -1,0 +1,16 @@
+import pytest
+from django.conf import settings
+
+from ..unoconv import Unoconv
+
+
+@pytest.mark.parametrize(
+    "unoconv_server,uses_external_unoconv", [(None, False), ("192.168.1.1", True)]
+)
+def test_unoconv_local(unoconv_server, uses_external_unoconv):
+    uc = Unoconv(
+        pythonpath=settings.UNOCONV_PYTHON,
+        unoconvpath=settings.UNOCONV_PATH,
+        server=unoconv_server,
+    )
+    assert (unoconv_server in uc.cmd) == uses_external_unoconv

--- a/document_merge_service/api/unoconv.py
+++ b/document_merge_service/api/unoconv.py
@@ -26,7 +26,7 @@ class Unoconv:
     def cmd(self):
         cmd = [self.pythonpath, self.unoconvpath]
 
-        if self.server:  # pragma: no cover
+        if self.server:
             cmd.extend(
                 [
                     "--server",

--- a/document_merge_service/settings.py
+++ b/document_merge_service/settings.py
@@ -2,9 +2,7 @@ import os
 import re
 
 import environ
-import requests
 from django.core.exceptions import ImproperlyConfigured
-from rest_framework import status
 
 from .api.unoconv import Unoconv
 
@@ -154,36 +152,20 @@ DEFAULT_FILE_STORAGE = env.str(
 )
 MEDIA_ROOT = env.str("MEDIA_ROOT", "")
 
-# Unoconv webservice
-# https://github.com/zrrrzzt/tfk-api-unoconv
-
 UNOCONV_ALLOWED_TYPES = env.list("UNOCOV_ALLOWED_TYPES", default=["pdf"])
-UNOCONV_URL = env.str("UNOCONV_URL", default="").rstrip("/")
-UNOCONV_LOCAL = env.bool("UNOCONV_LOCAL", default=False)
+UNOCONV_SERVER = env.str("UNOCONV_SERVER", default=None)
+UNOCONV_PORT = env.str("UNOCONV_PORT", default=2002)
 UNOCONV_PYTHON = env.str("UNOCONV_PYTHON", default="/usr/bin/python3")
 UNOCONV_PATH = env.str("UNOCONV_PATH", default="/usr/bin/unoconv")
 
 
 def get_unoconv_formats():
-    resp = requests.get(f"{UNOCONV_URL}/unoconv/formats")
-    if resp.status_code != status.HTTP_200_OK:
-        raise ImproperlyConfigured(
-            f"Configured unoconv service {UNOCONV_URL} doesn't respond correctly"
-        )
-
-    formats = {fmt["format"]: fmt for fmt in resp.json().get("document", [])}
-    not_supported = set(UNOCONV_ALLOWED_TYPES) - formats.keys()
-
-    if not_supported:
-        raise ImproperlyConfigured(
-            f"Unoconv doesn't support types {', '.join(not_supported)}."
-        )
-
-    return formats
-
-
-def get_unoconv_formats_local():
-    uno = Unoconv(pythonpath=UNOCONV_PYTHON, unoconvpath=UNOCONV_PATH)
+    uno = Unoconv(
+        pythonpath=UNOCONV_PYTHON,
+        unoconvpath=UNOCONV_PATH,
+        server=UNOCONV_SERVER,
+        port=UNOCONV_PORT,
+    )
     formats = uno.get_formats()
     not_supported = set(UNOCONV_ALLOWED_TYPES) - formats
 
@@ -195,11 +177,7 @@ def get_unoconv_formats_local():
     return formats
 
 
-UNOCONV_FORMATS = False
-if UNOCONV_LOCAL:  # pragma: no cover
-    UNOCONV_FORMATS = get_unoconv_formats_local()
-elif UNOCONV_URL:
-    UNOCONV_FORMATS = get_unoconv_formats()
+UNOCONV_FORMATS = get_unoconv_formats()
 
 # Jinja2
 DOCXTEMPLATE_JINJA_EXTENSIONS = env.list(

--- a/document_merge_service/tests/test_settings.py
+++ b/document_merge_service/tests/test_settings.py
@@ -4,26 +4,13 @@ from django.core.exceptions import ImproperlyConfigured
 from .. import settings
 
 
-@pytest.mark.parametrize(
-    "format_function", ["get_unoconv_formats", "get_unoconv_formats_local"]
-)
-def test_get_unoconv_formats(format_function):
-    formats = getattr(settings, format_function)()
+def test_get_unoconv_formats():
+    formats = settings.get_unoconv_formats()
     assert "pdf" in formats
 
 
-def test_get_unoconv_formats_invalid_url(monkeypatch):
-    monkeypatch.setattr(settings, "UNOCONV_URL", settings.UNOCONV_URL + "/invalid")
-
-    with pytest.raises(ImproperlyConfigured):
-        settings.get_unoconv_formats()
-
-
-@pytest.mark.parametrize(
-    "format_function", ["get_unoconv_formats", "get_unoconv_formats_local"]
-)
-def test_get_unoconv_formats_invalid_format(monkeypatch, format_function):
+def test_get_unoconv_formats_invalid_format(monkeypatch):
     monkeypatch.setattr(settings, "UNOCONV_ALLOWED_TYPES", ["invalid"])
 
     with pytest.raises(ImproperlyConfigured):
-        getattr(settings, format_function)()
+        settings.get_unoconv_formats()

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:buster-slim
+
+RUN apt-get update \
+ && apt-get install -y unoconv \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD /bin/sh -c "while true; do unoconv --server 0.0.0.0 --port 2002  --listener; done"


### PR DESCRIPTION
The tfk-api-unoconv webservice was initially added as a convenient way to interact with unoconv. In                                                                                                                                            
the meantime a UNCONV_LOCAL mode was added, to eliminate the dependency on the tfk-api-unoconv                                                                                                                                                 
webservice by running unoconv directly inside the document-merge-service container.                                                                                                                                                            
                                                                                                                                                                                                                                               
As a consequence of this new operation mode we had significant performance problems caused by                                                                                                                                                  
unoconv launching a headless libreoffice instance with every request.                                                                                                                                                                          
                                                                                                                                                                                                                                               
Doing some research we've learned that unoconv can be launched in a listener mode. Other unoconv                                                                                                                                               
clients can then dispatch their work to this listener. This way only a single libreoffice instance                                                                                                                                             
is used. (In fact tfk-api-unoconv does the very same thing)  