### PR TITLE
chore(compose): bump docker-compose file version

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   document-merge-service:
     image: adfinissygroup/document-merge-service:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   document-merge-service:
     image: adfinissygroup/document-merge-service


### PR DESCRIPTION
This commit bumps the compose file version from `3` to `3.4`.