### PR TITLE
Release 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,3 @@ install:
 script:
   - ./node_modules/.bin/commitlint-travis
   - make test
-
-after_success:
-  - git config --global user.name "semantic-release (via TravisCI)"
-  - git config --global user.email "semantic-release@travis"
-  - pip install python-semantic-release
-  - semantic-release publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 3.0.0
+
+### Fix
+* Revert automatic conversion, add filter instead (4e91c50a5938ab641a90cb84fabd56ff992c757c)
+
+### Breaking
+* Replace tfk-api-unoconv service with unoconv listener (f12f0a221b64fb22665ac4609e4f52e34ff767f2)
+  * `UNOCONV_LOCAL` and `UNOCONV_URL` are no longer supported configuration options. Please remove
+	them from your configuration file.
+  * By default an unoconv listener gets launched within the container. To use a different listener
+	you can specify `UNOCONV_SERVER` and `UNOCONV_PORT`.
+
+* After gathering some practical experience with the new automatic "Listing"-conversion for
+  multiline we noticed that this feature is a little bit too "clever" and breaks many advanced
+  use-cases. (4e91c50a5938ab641a90cb84fabd56ff992c757c)

--- a/document_merge_service/document_merge_service_metadata.py
+++ b/document_merge_service/document_merge_service_metadata.py
@@ -2,6 +2,6 @@
 
 __title__ = "document_merge_service"
 __description__ = "Merge Document Template Service"
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 __author__ = "Adfinis SyGroup AG"
 __url__ = "https://github.com/adfinis-sygroup/document-merge-service"

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,8 +76,3 @@ omit=
     document_merge_service/document_merge_service_metadata.py
 
 show_missing = True
-
-[semantic_release]
-version_variable=document_merge_service/document_merge_service_metadata.py:__version__
-branch=release
-upload_to_pypi=False


### PR DESCRIPTION
Because of various parsing problems of python-semantic-release we decided that
we are no longer going to use it for automatic releases. We will still use it to
generate the rough changelog, which is then manually curated.

Also see:
https://github.com/projectcaluma/caluma/pull/885
