### PR TITLE
fix(validation): don't reject templates with complex syntax

### DIFF
--- a/document_merge_service/api/tests/snapshots/snap_test_template.py
+++ b/document_merge_service/api/tests/snapshots/snap_test_template.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -559,6 +558,105 @@ snapshots[
     <w:pgMar w:top="1417" w:right="1417" w:bottom="1134" w:left="1417" w:header="708" w:footer="708" w:gutter="0"/>
     <w:cols w:space="708"/>
     <w:docGrid w:linePitch="360"/>
+  </w:sectPr>
+</w:body>
+"""
+
+snapshots[
+    "test_merge_expression[{{blah}}-template_content0] 1"
+] = """<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="Normal"/>
+      <w:rPr/>
+    </w:pPr>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t>Test</w:t>
+    </w:r>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t xml:space="preserve">: blub</w:t>
+    </w:r>
+  </w:p>
+  <w:sectPr>
+    <w:type w:val="nextPage"/>
+    <w:pgSz w:w="11906" w:h="16838"/>
+    <w:pgMar w:left="1134" w:right="1134" w:header="0" w:top="1134" w:footer="0" w:bottom="1134" w:gutter="0"/>
+    <w:pgNumType w:fmt="decimal"/>
+    <w:formProt w:val="false"/>
+    <w:textDirection w:val="lrTb"/>
+    <w:docGrid w:type="default" w:linePitch="240" w:charSpace="0"/>
+  </w:sectPr>
+</w:body>
+"""
+
+snapshots[
+    'test_merge_expression[{{NAME and ", represents " + NAME}}-template_content1] 1'
+] = """<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="Normal"/>
+      <w:rPr/>
+    </w:pPr>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t>Test</w:t>
+    </w:r>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t xml:space="preserve">: , represents foo</w:t>
+    </w:r>
+  </w:p>
+  <w:sectPr>
+    <w:type w:val="nextPage"/>
+    <w:pgSz w:w="11906" w:h="16838"/>
+    <w:pgMar w:left="1134" w:right="1134" w:header="0" w:top="1134" w:footer="0" w:bottom="1134" w:gutter="0"/>
+    <w:pgNumType w:fmt="decimal"/>
+    <w:formProt w:val="false"/>
+    <w:textDirection w:val="lrTb"/>
+    <w:docGrid w:type="default" w:linePitch="240" w:charSpace="0"/>
+  </w:sectPr>
+</w:body>
+"""
+
+snapshots[
+    'test_merge_expression[{{NAME and ", represents " + NAME}}-template_content2] 1'
+] = """<w:body xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="Normal"/>
+      <w:rPr/>
+    </w:pPr>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t>Test</w:t>
+    </w:r>
+    <w:r>
+      <w:rPr>
+        <w:lang w:val="de-CH" w:eastAsia="zh-CN" w:bidi="hi-IN"/>
+      </w:rPr>
+      <w:t xml:space="preserve">: </w:t>
+    </w:r>
+  </w:p>
+  <w:sectPr>
+    <w:type w:val="nextPage"/>
+    <w:pgSz w:w="11906" w:h="16838"/>
+    <w:pgMar w:left="1134" w:right="1134" w:header="0" w:top="1134" w:footer="0" w:bottom="1134" w:gutter="0"/>
+    <w:pgNumType w:fmt="decimal"/>
+    <w:formProt w:val="false"/>
+    <w:textDirection w:val="lrTb"/>
+    <w:docGrid w:type="default" w:linePitch="240" w:charSpace="0"/>
   </w:sectPr>
 </w:body>
 """


### PR DESCRIPTION
Jinja2 allows more complex syntax than just filling in placeholders. This confused
the validation logic, as Jinja couldn't handle our _MagicPlaceholder in some places.

This solves the problem by inheriting from UserString (basically `str`) and implementing
__radd__(), which implements the operator in question. Note that it possibly will need
more operators, depending on what the templates want to do. There's a parameterizable
test now to validate more expressions as they come up

Fixes #254 