### PR TITLE
chore(CI): ignore body-max-line-length in gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,2 +1,2 @@
 [general]
-ignore=body-is-missing
+ignore=body-is-missing,body-max-line-length


### PR DESCRIPTION
This is necessary, because dependabot is not following this convention.