### PR TITLE
Feat disable test render

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -196,6 +196,18 @@ in the example above would become something like:
 ...     ),
 ```
 
+### Disabling template validation
+
+Sometimes, templates contain advanced syntax that cannot be correctly validated
+by the automatic mechanism. If you at the same time are also unable to provide
+usable sample data, you can disable template validation entirely.
+
+Please note that in this case, templates will be accepted that may cause errors
+when actually used, so make sure to test them after uploading!
+
+To disable template validation, pass in the additional parameter
+`disable_template_validation` with the value `true` on template upload.
+
 
 ## Merging templates
 

--- a/document_merge_service/api/serializers.py
+++ b/document_merge_service/api/serializers.py
@@ -27,6 +27,9 @@ class CurrentGroupDefault:
 
 
 class TemplateSerializer(serializers.ModelSerializer):
+    disable_template_validation = serializers.BooleanField(
+        allow_null=True, default=False
+    )
     group = serializers.CharField(allow_null=True, default=CurrentGroupDefault())
     available_placeholders = serializers.ListField(allow_null=True, required=False)
     sample_data = serializers.JSONField(allow_null=True, required=False)
@@ -63,6 +66,12 @@ class TemplateSerializer(serializers.ModelSerializer):
         return sorted([x.replace(".[]", "[]") for x in _doc(sample_doc)])
 
     def validate(self, data):
+        if data.pop("disable_template_validation", False):
+            # Some template structures cannot be validated automatically,
+            # or it would be impossible or too much effort to provide accurate
+            # sample data. For those cases, we allow disabling the validation.
+            return data
+
         engine = data.get("engine", self.instance and self.instance.engine)
         template = data.get("template", self.instance and self.instance.template)
 
@@ -108,6 +117,7 @@ class TemplateSerializer(serializers.ModelSerializer):
             "available_placeholders",
             "sample_data",
             "files",
+            "disable_template_validation",
         )
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ flake8-docstrings==1.5.0
 flake8-isort==4.0.0
 flake8-string-format==0.3.0
 flake8-tuple==0.4.1
-gitlint==0.13.1
+gitlint==0.15.0
 isort==5.6.4
 pydocstyle==5.1.1
 pytest==6.1.1


### PR DESCRIPTION
Add new parameter `disable_template_validation` on template upload. This
can be used if you cannot provide correct sample data upon upload, and/or
the magic validation does not work.
