### PR TITLE
fix(subprocess): add timeout and cleanup orphan forks

### DIFF
--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -462,6 +462,7 @@ def test_template_create_with_available_placeholders(
         Document(io.BytesIO(response.content))
 
 
+@pytest.mark.parametrize("template__engine", [models.Template.DOCX_TEMPLATE])
 @pytest.mark.parametrize(
     "template_name,status_code",
     [

--- a/document_merge_service/api/unoconv.py
+++ b/document_merge_service/api/unoconv.py
@@ -1,17 +1,88 @@
+import os
 import re
-import subprocess
+import signal
 from collections import namedtuple
+from datetime import timedelta
 from mimetypes import guess_type
+from subprocess import PIPE, CalledProcessError, CompletedProcess, Popen, TimeoutExpired
 
 UnoconvResult = namedtuple(
     "UnoconvResult", ["stdout", "stderr", "returncode", "content_type"]
 )
 
 
-def run_subprocess(cmd):
-    return subprocess.run(
-        [str(arg) for arg in cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
+def getpgid(proc):
+    try:
+        return (proc, os.getpgid(proc.pid))
+    except ProcessLookupError:
+        return (proc, None)
+
+
+def kill(proc, sig):
+    process, group = proc
+    try:
+        if group is None:
+            if process.returncode is None:
+                os.kill(process.pid, sig)
+        else:
+            os.killpg(group, sig)
+    except ProcessLookupError:
+        pass
+
+
+def terminate_then_kill(proc):
+    process, _ = proc
+    kill(proc, signal.SIGTERM)
+    try:
+        process.wait(timeout=timedelta(seconds=1))
+    except TimeoutExpired:
+        pass
+    finally:
+        kill(proc, signal.SIGKILL)
+
+
+def run_fork_safe(
+    *popenargs,
+    input=None,
+    capture_output=False,
+    timeout=None,
+    check=False,
+    **kwargs,
+):
+    """Run command with arguments and return a CompletedProcess instance.
+
+    Works like `subprocess.run`, but puts the subprocess and its children in a new
+    process group, so orphan forks can be terminated, too.
+    """
+    if input is not None:
+        if kwargs.get("stdin") is not None:
+            raise ValueError("stdin and input arguments may not both be used.")
+        kwargs["stdin"] = PIPE
+
+    if capture_output:
+        if kwargs.get("stdout") is not None or kwargs.get("stderr") is not None:
+            raise ValueError(
+                "stdout and stderr arguments may not be used " "with capture_output."
+            )
+        kwargs["stdout"] = PIPE
+        kwargs["stderr"] = PIPE
+
+    with Popen(*popenargs, start_new_session=True, **kwargs) as process:
+        proc = getpgid(process)
+        try:
+            stdout, stderr = process.communicate(input, timeout=timeout)
+        finally:
+            terminate_then_kill(proc)
+        retcode = process.poll()
+        if check and retcode:
+            raise CalledProcessError(
+                retcode, process.args, output=stdout, stderr=stderr
+            )
+    return CompletedProcess(process.args, retcode, stdout, stderr)
+
+
+def run(cmd):
+    return run_fork_safe([str(arg) for arg in cmd], stdout=PIPE, stderr=PIPE)
 
 
 class Unoconv:
@@ -25,7 +96,7 @@ class Unoconv:
         self.cmd = [pythonpath, unoconvpath]
 
     def get_formats(self):
-        p = run_subprocess(self.cmd + ["--show"])
+        p = run(self.cmd + ["--show"])
         if not p.returncode == 0:  # pragma: no cover
             raise Exception("Failed to fetch the formats from unoconv!")
 
@@ -47,7 +118,7 @@ class Unoconv:
         :return: UnoconvResult()
         """
         # unoconv MUST be running with the same python version as libreoffice
-        p = run_subprocess(self.cmd + ["--format", convert, "--stdout", filename])
+        p = run(self.cmd + ["--format", convert, "--stdout", filename])
         stdout = p.stdout
         if not p.returncode == 0:  # pragma: no cover
             stdout = f"unoconv returncode: {p.returncode}"

--- a/document_merge_service/conftest.py
+++ b/document_merge_service/conftest.py
@@ -8,6 +8,7 @@ from factory.base import FactoryMetaClass
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
+from document_merge_service.api import models
 from document_merge_service.api.data import django_file
 
 from .api import engines
@@ -66,10 +67,11 @@ def admin_client(db, admin_user):
 @pytest.fixture
 def docx_template_with_placeholder(admin_client, template):
     """Return a factory function to build a docx template with a given placeholder."""
-
-    engine = engines.get_engine(template.engine, django_file("docx-template.docx"))
+    template.engine = models.Template.DOCX_TEMPLATE
+    template.save()
 
     def make_template(placeholder):
+        engine = engines.get_engine(template.engine, django_file("docx-template.docx"))
         binary = BytesIO()
         engine.merge({"test": placeholder}, binary)
         binary.seek(0)


### PR DESCRIPTION
the subprocess can exit normally but leave orphan forks, so after communicating
with the process, we terminate then kill the whole process-group.