### PR TITLE
fix(template): make template download url more stable

### DIFF
--- a/document_merge_service/api/serializers.py
+++ b/document_merge_service/api/serializers.py
@@ -1,6 +1,7 @@
 from functools import singledispatch
 
 from django.conf import settings
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from rest_framework import exceptions, serializers
 
@@ -17,6 +18,15 @@ class CustomFileField(serializers.FileField):
 
     def to_representation(self, value):
         return value or None
+
+
+class TemplateFileField(serializers.FileField):
+    def to_representation(self, value):
+        if not value:
+            return None
+
+        if self.parent.instance:
+            return reverse("template-download", args=[self.parent.instance.pk])
 
 
 class CurrentGroupDefault:
@@ -36,6 +46,7 @@ class TemplateSerializer(serializers.ModelSerializer):
     files = serializers.ListField(
         child=CustomFileField(write_only=True, allow_empty_file=False), required=False
     )
+    template = TemplateFileField()
 
     def validate_group(self, group):
         request = self.context["request"]

--- a/document_merge_service/api/urls.py
+++ b/document_merge_service/api/urls.py
@@ -9,7 +9,7 @@ r.register("template", views.TemplateView)
 
 urlpatterns = [
     re_path(
-        r"^template/(?P<template>.+\..+)$",
+        r"^template-download/(?P<pk>.+)$",
         views.DownloadTemplateView.as_view(),
         name="template-download",
     )

--- a/document_merge_service/api/views.py
+++ b/document_merge_service/api/views.py
@@ -88,7 +88,7 @@ class TemplateView(viewsets.ModelViewSet):
 
 class DownloadTemplateView(RetrieveAPIView):
     queryset = models.Template.objects
-    lookup_field = "template"
+    lookup_field = "pk"
 
     def retrieve(self, request, **kwargs):
         template = self.get_object()


### PR DESCRIPTION
A lot of things here only worked accidentally. We need to be more explicit
about the download URL and don't mount the download view in the same place
where the API resides (/api/v1/templates/foo would use the REST endpoint,
while /api/v1/templates/foo.docx would trigger the download of the
template document.)

Now, the template download is found under /api/v1/template-download/(slug),
which separates those concerns. The download URL was also only implicitly
correct and doesn't work if circumstances don't exactly match the expectation.

Non-breaking, as the API now just outputs the new URL, which is the URL
used by the frontend anyway.