### PR TITLE
fix(api): do not crash in list view

### DIFF
--- a/document_merge_service/api/serializers.py
+++ b/document_merge_service/api/serializers.py
@@ -21,12 +21,16 @@ class CustomFileField(serializers.FileField):
 
 
 class TemplateFileField(serializers.FileField):
-    def to_representation(self, value):
-        if not value:
-            return None
+    def get_attribute(self, instance):
+        # Hacky workaround - we need the instance in `to_representation()`,
+        # not the field value.
+        # We cannot use `parent.instance`, as that won't be set to
+        # the current instance in a list view
+        return instance
 
-        if self.parent.instance:
-            return reverse("template-download", args=[self.parent.instance.pk])
+    def to_representation(self, value):
+        if value and value.pk and value.template:
+            return reverse("template-download", args=[value.pk])
 
 
 class CurrentGroupDefault:

--- a/document_merge_service/api/tests/test_template.py
+++ b/document_merge_service/api/tests/test_template.py
@@ -83,6 +83,18 @@ def test_template_download(db, client, template):
     assert file.read() == template_resp.content
 
 
+def test_template_list_with_file(db, client, template):
+    file = django_file("docx-template-syntax.docx")
+    template.template.save(os.path.basename(file.name), file)
+    template.save()
+
+    url = reverse("template-list")
+    response = client.get(url)
+
+    assert response.json()["results"][0]["template"] is not None
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_template_download_url(db, client, template):
     file = django_file("docx-template-syntax.docx")
     template.template.save(os.path.basename(file.name), file)

--- a/document_merge_service/urls.py
+++ b/document_merge_service/urls.py
@@ -2,4 +2,8 @@ from django.conf import settings
 from django.conf.urls import include
 from django.urls import re_path
 
-urlpatterns = [re_path(f"^{settings.URL_PREFIX}api/v1/", include("document_merge_service.api.urls"))]
+urlpatterns = [
+    re_path(
+        f"^{settings.URL_PREFIX}api/v1/", include("document_merge_service.api.urls")
+    )
+]


### PR DESCRIPTION
The previous change crashed the API in list view if we had any template
with an actual template file attached. Fix this, so that the list
actually returns data as well